### PR TITLE
[RFC] Add engine for bonds

### DIFF
--- a/src/Offboard/Engine.php
+++ b/src/Offboard/Engine.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Moscow Exchange ISS Client
+ *
+ * @link      http://github.com/panychek/moex
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @author    Igor Panychek panychek@gmail.com
+ */
+
+namespace Panychek\MoEx\Offboard;
+
+class Engine extends \Panychek\MoEx\Engine
+{
+    /**
+     * @var string
+     */
+    protected $id = 'offboard';
+}


### PR DESCRIPTION
Add missed engine for bonds.

Code:
```
        $security = new Security('SU26210RMFS3');
        $security->getHistoricalQuotes('2019-05-01', '2019-05-10');
```

Exception:
```
In Engine.php line 46:

  [ClassNotFoundException]
  Attempted to load class "Engine" from namespace "Panychek\MoEx\Offboard".
  Did you forget a "use" statement for e.g. "Panychek\MoEx\Commodity\Engine",
  "Panychek\MoEx\Currency\Engine", "Panychek\MoEx\Engine", "Panychek\MoEx\Futu
  res\Engine", "Panychek\MoEx\Interventions\Engine", "Panychek\MoEx\State\Engi
  ne" or "Panychek\MoEx\Stock\Engine"?


Exception trace:
 () at vendor/panychek/moex/src/Engine.php:46
 Panychek\MoEx\Engine::getInstance() at vendor/panychek/moex/src/Board.php:103
 Panychek\MoEx\Board->setEngine() at vendor/panychek/moex/src/Board.php:50
 Panychek\MoEx\Board->__construct() at vendor/panychek/moex/src/Board.php:65
 Panychek\MoEx\Board::getInstance() at vendor/panychek/moex/src/Security.php:164
 Panychek\MoEx\Security->setAvailableBoards() at vendor/panychek/moex/src/Security.php:125
 Panychek\MoEx\Security->loadInfo() at vendor/panychek/moex/src/Security.php:149
 Panychek\MoEx\Security->getBoard() at vendor/panychek/moex/src/Security.php:199
 Panychek\MoEx\Security->getEngine() at vendor/panychek/moex/src/Security.php:448
 Panychek\MoEx\Security->setHistoryData() at vendor/panychek/moex/src/Security.php:436
 Panychek\MoEx\Security->getHistoricalQuotes() at ...
```